### PR TITLE
Quick fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,9 +5,7 @@ set(SOURCE_FILES
     debugcontrol.cpp
     debugger.cpp
     debugnet.cpp
-    elf.cpp
     emulog.cpp
-    loader.cpp
     main.cpp
     )
 set(HEADER_FILES
@@ -16,9 +14,7 @@ set(HEADER_FILES
     debugger.h
     debugmsg.h
     debugnet.h
-    elf.h
     hostlookup.h
-    loader.h
     traceiter.h
     types.h
     usermodule.h

--- a/src/debugnet.cpp
+++ b/src/debugnet.cpp
@@ -114,7 +114,7 @@ struct DebugPauseInfo {
 static void
 populateDebugPauseInfo(DebugPauseInfo& info)
 {
-   auto &loadedModules = coreinit::internal::getLoadedModules();
+   const auto &loadedModules = coreinit::internal::getLoadedModules();
    int moduleIdx = 0;
    int userModuleIdx = -1;
    auto userModule = coreinit::internal::getUserModule();

--- a/src/filesystem/filesystem_virtual_folder.h
+++ b/src/filesystem/filesystem_virtual_folder.h
@@ -11,7 +11,7 @@ namespace fs
 class VirtualFolder : public Folder
 {
 public:
-   VirtualFolder(std::string name) :
+   VirtualFolder(const std::string &name) :
       Folder(name)
    {
    }

--- a/src/gpu/microcode/latte_blockify.cpp
+++ b/src/gpu/microcode/latte_blockify.cpp
@@ -341,7 +341,7 @@ blockify(Shader &shader)
  * Recursive function to dump a list of blocks to string.
  */
 static void
-dumpBlockList(shadir::BlockList &blocks, fmt::MemoryWriter &out, std::string indent)
+dumpBlockList(shadir::BlockList &blocks, fmt::MemoryWriter &out, const std::string &indent)
 {
    for (auto &block : blocks) {
       switch (block->type) {

--- a/src/kernel/kernel_hlemodule.h
+++ b/src/kernel/kernel_hlemodule.h
@@ -5,6 +5,7 @@
 #include "kernel_hlefunction.h"
 #include "kernel_hledata.h"
 #include "common/virtual_ptr.h"
+#include "ppcutils/wfunc_ptr.h"
 
 #define RegisterKernelFunction(fn) \
    RegisterKernelFunctionName(#fn, fn)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ initialiseEmulator();
 static bool
 play(const fs::HostPath &path);
 
-static const std::string
+static std::string
 getGameName(const fs::HostPath &path)
 {
    return path.filename();

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCE_FILES
     coreinit/coreinit_ghs_typeinfo.cpp
     coreinit/coreinit_interrupts.cpp
     coreinit/coreinit_internal_idlock.cpp
+    coreinit/coreinit_internal_loader.cpp
     coreinit/coreinit_lockedcache.cpp
     coreinit/coreinit_mcp.cpp
     coreinit/coreinit_memheap.cpp
@@ -44,6 +45,7 @@ set(SOURCE_FILES
     coreinit/coreinit_time.cpp
     coreinit/coreinit_unitheap.cpp
     coreinit/coreinit_userconfig.cpp
+    coreinit/elf.cpp
     erreula/erreula.cpp
     erreula/erreula_errorviewer.cpp
     gx2/gx2.cpp
@@ -169,6 +171,7 @@ set(HEADER_FILES
     coreinit/coreinit_ghs_typeinfo.h
     coreinit/coreinit_interrupts.h
     coreinit/coreinit_internal_idlock.h
+    coreinit/coreinit_internal_loader.h
     coreinit/coreinit_internal_queue.h
     coreinit/coreinit_ios.h
     coreinit/coreinit_lockedcache.h
@@ -189,6 +192,7 @@ set(HEADER_FILES
     coreinit/coreinit_time.h
     coreinit/coreinit_unitheap.h
     coreinit/coreinit_userconfig.h
+    coreinit/elf.h
     erreula/erreula.h
     erreula/erreula_errorviewer.h
     gx2/gx2.h


### PR DESCRIPTION
FIxes compile time errors with caused by const-ness, include files and cmake. src/CMakeLists.txt has been modified to reflect directory structure changes introduced in a recent commit.